### PR TITLE
Frontend: login/register pages + auth state management

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -145,3 +145,11 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173", # フロントエンドのURL
 ]
 CORS_ALLOW_CREDENTIALS = True # クッキーなどの資格情報を許可する場合
+
+# Django's CSRF origin check (Django >=4) compares request Origin header against
+# CSRF_TRUSTED_ORIGINS when present. For development we allow the frontend dev
+# server so POST requests from the SPA are accepted.
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:5173',
+    'http://127.0.0.1:5173',
+]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,13 +1,16 @@
 import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
+import AuthHeader from './components/AuthHeader';
 import './App.css'
 
 function App() {
   const [count, setCount] = useState(0)
 
   return (
-    <>
+    <div className="app-root">
+      <AuthHeader />
+      <main style={{ padding: 20 }}>
       <div>
         <a href="https://vite.dev" target="_blank">
           <img src={viteLogo} className="logo" alt="Vite logo" />
@@ -28,7 +31,8 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
-    </>
+      </main>
+    </div>
   )
 }
 

--- a/frontend/src/components/AuthHeader.jsx
+++ b/frontend/src/components/AuthHeader.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function AuthHeader() {
+  const { user, loading, logout } = useAuth();
+  const navigate = useNavigate();
+
+  async function handleLogout(e) {
+    e.preventDefault();
+    try {
+      await logout();
+      navigate('/login');
+    } catch (err) {
+      console.error('Logout failed', err);
+    }
+  }
+
+  return (
+    <header className="app-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 16px', borderBottom: '1px solid #eee' }}>
+      <div className="brand">
+        <Link to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
+          <strong>Scorpion</strong>
+        </Link>
+      </div>
+
+      <div className="auth-controls">
+        {loading ? (
+          <span>Loading...</span>
+        ) : user ? (
+          <>
+            <span style={{ marginRight: 12 }}>Hi, {user.username}</span>
+            <button onClick={handleLogout}>Logout</button>
+          </>
+        ) : (
+          <>
+            <Link to="/login" style={{ marginRight: 8 }}>Login</Link>
+            <Link to="/register">Register</Link>
+          </>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/RequireAuth.jsx
+++ b/frontend/src/components/RequireAuth.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function RequireAuth({ children }) {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) return <div>Loading...</div>;
+  if (!user) return <Navigate to="/login" state={{ from: location }} replace />;
+  return children;
+}

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,0 +1,64 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as authApi from '../services/authApi';
+
+const AuthContext = createContext({});
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => {
+    try {
+      const raw = localStorage.getItem('currentUser');
+      return raw ? JSON.parse(raw) : null;
+    } catch (err) {
+      return null;
+    }
+  });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // try to fetch current user when app loads
+    async function loadUser() {
+      try {
+        const resp = await authApi.me();
+        setUser(resp.data);
+      } catch (err) {
+        // not logged in
+        setUser(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadUser();
+  }, []);
+
+  const login = async ({ username, password }) => {
+    await authApi.login({ username, password });
+    const resp = await authApi.me();
+    setUser(resp.data);
+    return resp.data;
+  };
+
+  const register = async (payload) => {
+    return authApi.register(payload);
+  };
+
+  const logout = async () => {
+    await authApi.logout();
+    setUser(null);
+  };
+
+  // persist user to localStorage so refresh has immediate state
+  useEffect(() => {
+    if (user) localStorage.setItem('currentUser', JSON.stringify(user));
+    else localStorage.removeItem('currentUser');
+  }, [user]);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,12 +1,23 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { AuthProvider } from './contexts/AuthContext';
 import App from './App.jsx'; // メインのレイアウトコンポーネント
 import CheckInPage from './pages/CheckInPage';
 import GuestFormPage from './pages/GuestFormPage';
 import RevenuePage from './pages/RevenuePage'; // 追加
+import RequireAuth from './components/RequireAuth';
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
 import './index.css';
 
+    path: '/login',
+    element: <LoginPage />,
+  },
+  {
+    path: '/register',
+    element: <RegisterPage />,
+  },
 const router = createBrowserRouter([
   {
     path: '/',
@@ -23,12 +34,18 @@ const router = createBrowserRouter([
   },
   {
     path: '/revenue', // 売上レポートページのルートを追加
-    element: <RevenuePage />,
+    element: (
+      <RequireAuth>
+        <RevenuePage />
+      </RequireAuth>
+    ),
   },
 ]);
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -11,6 +11,8 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import './index.css';
 
+const router = createBrowserRouter([
+  {
     path: '/login',
     element: <LoginPage />,
   },
@@ -18,7 +20,6 @@ import './index.css';
     path: '/register',
     element: <RegisterPage />,
   },
-const router = createBrowserRouter([
   {
     path: '/',
     element: <App />,

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+
+  const { login: loginAction } = useAuth();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await loginAction({ username, password });
+      // on success, redirect to home
+      navigate('/');
+    } catch (err) {
+      setError(err?.response?.data?.detail || 'Login failed');
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit} className="auth-form">
+        <div>
+          <label>Username</label>
+          <input value={username} onChange={(e) => setUsername(e.target.value)} />
+        </div>
+        <div>
+          <label>Password</label>
+          <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        {error && <div className="error">{error}</div>}
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function RegisterPage() {
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [password2, setPassword2] = useState('');
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+
+  const { register: registerAction } = useAuth();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    if (password !== password2) {
+      setError('Passwords do not match');
+      return;
+    }
+    try {
+      await registerAction({ username, email, password, password2 });
+      navigate('/login');
+    } catch (err) {
+      setError(err?.response?.data || 'Registration failed');
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <h2>Register</h2>
+      <form onSubmit={handleSubmit} className="auth-form">
+        <div>
+          <label>Username</label>
+          <input value={username} onChange={(e) => setUsername(e.target.value)} />
+        </div>
+        <div>
+          <label>Email</label>
+          <input value={email} onChange={(e) => setEmail(e.target.value)} />
+        </div>
+        <div>
+          <label>Password</label>
+          <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        <div>
+          <label>Confirm Password</label>
+          <input type="password" value={password2} onChange={(e) => setPassword2(e.target.value)} />
+        </div>
+        {error && <div className="error">{JSON.stringify(error)}</div>}
+        <button type="submit">Create account</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/services/authApi.js
+++ b/frontend/src/services/authApi.js
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: 'http://localhost:8000/api',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true, // allow cookies (session-based auth)
+});
+
+export const register = ({ username, email, password, password2 }) => {
+  return apiClient.post('/auth/register/', { username, email, password, password2 });
+};
+
+export const login = ({ username, password }) => {
+  return apiClient.post('/auth/login/', { username, password });
+};
+
+export const logout = () => {
+  return apiClient.post('/auth/logout/');
+};
+
+export const me = () => {
+  return apiClient.get('/auth/me/');
+};

--- a/frontend/src/services/authApi.js
+++ b/frontend/src/services/authApi.js
@@ -5,21 +5,27 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true, // allow cookies (session-based auth)
+  withCredentials: true,
 });
 
-export const register = ({ username, email, password, password2 }) => {
-  return apiClient.post('/auth/register/', { username, email, password, password2 });
-};
+export const register = ({ username, email, password, password2 }) =>
+  apiClient.post('/auth/register/', { username, email, password, password2 });
 
-export const login = ({ username, password }) => {
-  return apiClient.post('/auth/login/', { username, password });
-};
+export const login = ({ username, password }) =>
+  apiClient.post('/auth/login/', { username, password });
+
+export const me = () => apiClient.get('/auth/me/');
 
 export const logout = () => {
-  return apiClient.post('/auth/logout/');
+  // read csrftoken from document.cookie in the browser
+  const getCookie = (name) => {
+    if (typeof document === 'undefined') return '';
+    const match = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
+    return match ? match.pop() : '';
+  };
+
+  const token = getCookie('csrftoken');
+  return apiClient.post('/auth/logout/', {}, { headers: { 'X-CSRFToken': token } });
 };
 
-export const me = () => {
-  return apiClient.get('/auth/me/');
-};
+export default apiClient;

--- a/frontend/src/services/authApi.js
+++ b/frontend/src/services/authApi.js
@@ -17,15 +17,36 @@ export const login = ({ username, password }) =>
 export const me = () => apiClient.get('/auth/me/');
 
 export const logout = () => {
-  // read csrftoken from document.cookie in the browser
+  // Ensure CSRF cookie is present and send header. If missing, fetch /auth/csrf/ first.
   const getCookie = (name) => {
     if (typeof document === 'undefined') return '';
     const match = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
     return match ? match.pop() : '';
   };
 
-  const token = getCookie('csrftoken');
-  return apiClient.post('/auth/logout/', {}, { headers: { 'X-CSRFToken': token } });
+  const ensureCsrf = async () => {
+    const token = getCookie('csrftoken');
+    if (token) return token;
+    // fetch endpoint to set cookie (credentials required)
+    await fetch('http://localhost:8000/api/auth/csrf/', { credentials: 'include' });
+    return getCookie('csrftoken');
+  };
+
+  return (async () => {
+    const token = await ensureCsrf();
+    const headers = token ? { 'X-CSRFToken': token } : {};
+    try {
+      return await apiClient.post('/auth/logout/', {}, { headers });
+    } catch (err) {
+      // If the first attempt failed due to CSRF, refresh token and retry once
+      if (err?.response?.status === 403) {
+        const token2 = await ensureCsrf();
+        const headers2 = token2 ? { 'X-CSRFToken': token2 } : {};
+        return apiClient.post('/auth/logout/', {}, { headers: headers2 });
+      }
+      throw err;
+    }
+  })();
 };
 
 export default apiClient;


### PR DESCRIPTION
Adds login and registration pages, an authApi wrapper to call backend /api/auth endpoints, an AuthProvider (context) to maintain auth state and persist it to localStorage, and a RequireAuth wrapper to protect routes. This implements issues #2 #3 #6 #7 and implements client-side validation and navigation on success.